### PR TITLE
Prevent creating another document.

### DIFF
--- a/packages/dom/src/wc-clone.js
+++ b/packages/dom/src/wc-clone.js
@@ -50,9 +50,10 @@ const deepClone = host => {
  * Deep clone a document while also preserving shadow roots and converting adoptedStylesheets to <style> tags.
  */
 const cloneNodeAndShadow = doc => {
-  let clonedDocument = doc.cloneNode(true);
-  clonedDocument.documentElement.replaceWith(deepClone(doc.documentElement));
-  return clonedDocument;
+  let mockDocument = deepClone(doc.documentElement);
+  mockDocument.head = document.createDocumentFragment();
+  mockDocument.documentElement = mockDocument.firstChild;
+  return mockDocument;
 };
 
 /**


### PR DESCRIPTION
In testing I discovered that after the Percy snapshots completed, Stencil was causing a DOM exception

![image](https://user-images.githubusercontent.com/4644716/165354480-9dad9ce7-3ee6-496d-8211-4911a53181c6.png)

After investigating, the root of the issue stems from Stencil maintaining a Map of stylesheets globally that it then tries to apply to any stencil component, regardless of the component's ownerDocument. The easiest way around this problem is to just not create a new document context when cloning the content, maintaining a document fragment instead. Percy doesn't really care whether it's a document or a document fragment, It is able to capture them either way.

Per the specification, adopted stylesheets cannot be shared across documents. https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet#obtaining_a_stylesheet

I found a similar issue from 2019 in Stencil where the author was seeing an error trying to use web components in the context of an iframe: https://github.com/ionic-team/stencil/issues/1866

Within Stencil's runtime, the issue could be resolved by guarding against assigning stylesheets that have different documentOwners from the assignee node. https://github.com/ionic-team/stencil/blob/cb8eebcd5a6301a38d385e3eaf46bed694422cc6/src/runtime/styles.ts#L35-L37

```#suggestion
-   } else if (BUILD.constructableCSS && !styleContainerNode.adoptedStyleSheets.includes(style)) {
+   } else if (BUILD.constructableCSS && !styleContainerNode.adoptedStyleSheets.includes(style) && styleContainerNode.documentOwner === document) {
```